### PR TITLE
cmd,core: expose no remote for txpool config

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -73,6 +73,7 @@ var (
 		utils.EthashDatasetsOnDiskFlag,
 		utils.TxPoolLocalsFlag,
 		utils.TxPoolNoLocalsFlag,
+		utils.TxPoolNoRemotesFlag,
 		utils.TxPoolJournalFlag,
 		utils.TxPoolRejournalFlag,
 		utils.TxPoolPriceLimitFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -254,6 +254,10 @@ var (
 		Name:  "txpool.nolocals",
 		Usage: "Disables price exemptions for locally submitted transactions",
 	}
+	TxPoolNoRemotesFlag = cli.BoolFlag{
+		Name:  "txpool.noremotes",
+		Usage: "Disables submitted transactions remotely",
+	}
 	TxPoolJournalFlag = cli.StringFlag{
 		Name:  "txpool.journal",
 		Usage: "Disk journal for local transaction to survive node restarts",
@@ -1053,6 +1057,9 @@ func setTxPool(ctx *cli.Context, cfg *core.TxPoolConfig) {
 	}
 	if ctx.GlobalIsSet(TxPoolNoLocalsFlag.Name) {
 		cfg.NoLocals = ctx.GlobalBool(TxPoolNoLocalsFlag.Name)
+	}
+	if ctx.GlobalIsSet(TxPoolNoRemotesFlag.Name) {
+		cfg.NoRemotes = ctx.GlobalBool(TxPoolNoRemotesFlag.Name)
 	}
 	if ctx.GlobalIsSet(TxPoolJournalFlag.Name) {
 		cfg.Journal = ctx.GlobalString(TxPoolJournalFlag.Name)

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -140,6 +140,7 @@ type blockChain interface {
 type TxPoolConfig struct {
 	Locals    []common.Address // Addresses that should be treated by default as local
 	NoLocals  bool             // Whether local transaction handling should be disabled
+	NoRemotes bool             // Whether remote transaction can be added to the pool
 	Journal   string           // Journal of local transactions to survive node restarts
 	Rejournal time.Duration    // Time interval to regenerate the local transaction journal
 
@@ -897,7 +898,10 @@ func (pool *TxPool) AddLocal(tx *types.Transaction) error {
 // sender is not among the locally tracked ones, full pricing constraints will
 // apply.
 func (pool *TxPool) AddRemote(tx *types.Transaction) error {
-	return pool.addTx(tx, false)
+	if !pool.config.NoRemotes {
+		return pool.addTx(tx, false)
+	}
+	return nil
 }
 
 // AddLocals enqueues a batch of transactions into the pool if they are valid,


### PR DESCRIPTION
implement to resolve #101 

by the way, OOM due to goroutine leak reported in #104 so the handling txpool's tnx might not the real problem as we think in #101 