### PR TITLE
Resolve deadlock due to low sync and offline signer

### DIFF
--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -155,7 +155,7 @@ func (hc *HeaderChain) WriteHeader(header *types.Header) (status WriteStatus, er
 	// If the total difficulty is higher than our known, add it to the canonical chain
 	// Second clause in the if statement reduces the vulnerability to selfish mining.
 	// Please refer to http://www.cs.cornell.edu/~ie53/publications/btcProcFC.pdf
-	if externTd.Cmp(localTd) > 0 || (externTd.Cmp(localTd) == 0 && mrand.Float64() < 0.5) {
+	if ChainCompare(externTd, localTd, hash, hc.currentHeaderHash) > 0 {
 		// Delete any canonical number assignments above the new head
 		batch := hc.chainDb.NewBatch()
 		for i := number + 1; ; i++ {

--- a/eth/fetcher/fetcher.go
+++ b/eth/fetcher/fetcher.go
@@ -67,6 +67,12 @@ type chainInsertFn func(types.Blocks) (int, error)
 // peerDropFn is a callback type for dropping a peer detected as malicious.
 type peerDropFn func(id string)
 
+// peerHeaderRequesterFn is a callback type for sending a header retrieval request.
+type peerHeaderRequesterFn func(string) func(common.Hash) error
+
+// peerBodyRequesterFn is a callback type for sending a body retrieval request.
+type peerBodyRequesterFn func(string) func([]common.Hash) error
+
 // announce is the hash notification of the availability of a new block in the
 // network.
 type announce struct {
@@ -136,6 +142,8 @@ type Fetcher struct {
 	chainHeight    chainHeightFn      // Retrieves the current chain's height
 	insertChain    chainInsertFn      // Injects a batch of blocks into the chain
 	dropPeer       peerDropFn         // Drops a peer for misbehaving
+	headerRequest  peerHeaderRequesterFn
+	bodyRequest    peerBodyRequesterFn
 
 	// Testing hooks
 	announceChangeHook func(common.Hash, bool) // Method to call upon adding or deleting a hash from the announce list
@@ -146,7 +154,7 @@ type Fetcher struct {
 }
 
 // New creates a block fetcher to retrieve blocks based on hash announcements.
-func New(getBlock blockRetrievalFn, verifyHeader headerVerifierFn, broadcastBlock blockBroadcasterFn, chainHeight chainHeightFn, insertChain chainInsertFn, dropPeer peerDropFn) *Fetcher {
+func New(getBlock blockRetrievalFn, verifyHeader headerVerifierFn, broadcastBlock blockBroadcasterFn, chainHeight chainHeightFn, insertChain chainInsertFn, dropPeer peerDropFn, headerRequest peerHeaderRequesterFn, bodyRequest peerBodyRequesterFn) *Fetcher {
 	return &Fetcher{
 		notify:         make(chan *announce),
 		inject:         make(chan *inject),
@@ -169,6 +177,8 @@ func New(getBlock blockRetrievalFn, verifyHeader headerVerifierFn, broadcastBloc
 		chainHeight:    chainHeight,
 		insertChain:    insertChain,
 		dropPeer:       dropPeer,
+		headerRequest:  headerRequest,
+		bodyRequest:    bodyRequest,
 	}
 }
 
@@ -298,17 +308,35 @@ func (f *Fetcher) loop() {
 			}
 			// If too high up the chain or phase, continue later
 			number := op.block.NumberU64()
-			if number > height+1 {
-				f.queue.Push(op, -int64(number))
-				if f.queueChangeHook != nil {
-					f.queueChangeHook(hash, true)
-				}
-				break
-			}
 			// Otherwise if fresh and still unknown, try and import
 			if number+maxUncleDist < height || f.getBlock(hash) != nil {
 				f.forgetBlock(hash)
 				continue
+			}
+			parentHash := op.block.ParentHash()
+			if f.getBlock(parentHash) == nil {
+				f.queue.Push(op, -int64(number))
+				if f.queueChangeHook != nil {
+					f.queueChangeHook(hash, true)
+				}
+				if len(f.announced[parentHash]) > 0 {
+					// only request for parent hash once
+					break
+				}
+				headerRequestFn := f.headerRequest(op.origin)
+				bodyRequestFn := f.bodyRequest(op.origin)
+				if headerRequestFn == nil || bodyRequestFn == nil {
+					log.Info("Peer lost while fetching for parent", "peer", op.origin)
+					break
+				}
+				go func() {
+					log.Info("Notify of parent hash", "hash", parentHash, "number", op.block.NumberU64()-1, "peer", op.origin)
+					err := f.Notify(op.origin, parentHash, op.block.NumberU64()-1, time.Now(), headerRequestFn, bodyRequestFn)
+					if err != nil {
+						log.Error("Unable to notify of parent block", "error", err)
+					}
+				}()
+				break
 			}
 			f.insert(op.origin, op.block)
 		}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -678,7 +678,8 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			// a single block (as the true TD is below the propagated block), however this
 			// scenario should easily be covered by the fetcher.
 			currentBlock := pm.blockchain.CurrentBlock()
-			if trueTD.Cmp(pm.blockchain.GetTd(currentBlock.Hash(), currentBlock.NumberU64())) > 0 {
+			currentTd := pm.blockchain.GetTd(currentBlock.Hash(), currentBlock.NumberU64())
+			if core.ChainCompare(trueTD, currentTd, trueHead, currentBlock.Hash()) > 0 {
 				go pm.synchronise(p)
 			}
 		}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -182,7 +182,19 @@ func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, ne
 		atomic.StoreUint32(&manager.acceptTxs, 1) // Mark initial sync done on any fetcher import
 		return manager.blockchain.InsertChain(blocks)
 	}
-	manager.fetcher = fetcher.New(blockchain.GetBlockByHash, validator, manager.BroadcastBlock, heighter, inserter, manager.removePeer)
+	headerRequest := func(id string) func(common.Hash) error {
+		if peer := manager.peers.Peer(id); peer != nil {
+			return peer.RequestOneHeader
+		}
+		return nil
+	}
+	bodyRequest := func(id string) func([]common.Hash) error {
+		if peer := manager.peers.Peer(id); peer != nil {
+			return peer.RequestBodies
+		}
+		return nil
+	}
+	manager.fetcher = fetcher.New(blockchain.GetBlockByHash, validator, manager.BroadcastBlock, heighter, inserter, manager.removePeer, headerRequest, bodyRequest)
 
 	return manager, nil
 }

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/log"
@@ -172,15 +173,13 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 	td := pm.blockchain.GetTd(hash, currentBlock.NumberU64())
 
 	pHead, pTd := peer.Head()
-	// Skip if lesser total difficulty, or same TD and same hash.
-	if cmp := pTd.Cmp(td); cmp < 0 {
-		return
-	} else if cmp == 0 {
-		dccs := pm.blockchain.Config().IsThangLong(currentBlock.Number())
-		if !dccs || pHead == hash {
-			return
+	cmp := core.ChainCompare(pTd, td, pHead, hash)
+	if cmp <= 0 {
+		if cmp < 0 && currentBlock.NumberU64() > 0 {
+			// broadcast our better chain back to the peer
+			go pm.BroadcastBlock(currentBlock, true)
 		}
-		// only download the 'same TD - diff hash' after the DCCS hardfork
+		return
 	}
 
 	// Otherwise try to sync with the downloader
@@ -200,7 +199,9 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 
 	if mode == downloader.FastSync {
 		// Make sure the peer's total difficulty we are synchronizing is higher.
-		if pm.blockchain.GetTdByHash(pm.blockchain.CurrentFastBlock().Hash()).Cmp(pTd) >= 0 {
+		fastBlock := pm.blockchain.CurrentFastBlock()
+		fastTd := pm.blockchain.GetTd(fastBlock.Hash(), fastBlock.NumberU64())
+		if core.ChainCompare(pTd, fastTd, pHead, fastBlock.Hash()) <= 0 {
 			return
 		}
 	}


### PR DESCRIPTION
To fix #95

## ROOT CAUSE

consensuses with high rate of fork are not properly handled by geth, because nodes failed to switching from 2 disconnected forks.

## STEP REPRODUCE

The issue happens randomly, here is some factors to increase the chance of reproduction:

- Shorter blocktime: 1s
- Low connectivity (use --maxpeers=4 for network of 5/6)
- High latency and loss package: use Linux tool: "tc qdisc netem" to configure the network for this. (delay 0-500ms, block lost rate = 0.1-0.9%)

## SOLUTION
- Consistent chain compare rule. (This is badly done by PoA)
- When syncing with other peer (usually the best peer), in case the remote chain is worse than local chain, node should broadcast his better chain back to the network, or atleast the target peer.
- When importing a block with unknown parent, node should request (from the same peer) the parent block instead of discard the original block.