### PR TITLE
core: pre-calculate transaction senders before locking txpool

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -912,6 +912,9 @@ func (pool *TxPool) AddRemotes(txs []*types.Transaction) []error {
 
 // addTx enqueues a single transaction into the pool if it is valid.
 func (pool *TxPool) addTx(tx *types.Transaction, local bool) error {
+	// Cache sender in transaction before obtaining lock (pool.signer is immutable)
+	types.Sender(pool.signer, tx)
+
 	pool.mu.Lock()
 	defer pool.mu.Unlock()
 
@@ -930,6 +933,11 @@ func (pool *TxPool) addTx(tx *types.Transaction, local bool) error {
 
 // addTxs attempts to queue a batch of transactions if they are valid.
 func (pool *TxPool) addTxs(txs []*types.Transaction, local bool) []error {
+	// Cache senders in transactions before obtaining lock (pool.signer is immutable)
+	for _, tx := range txs {
+		types.Sender(pool.signer, tx)
+	}
+
 	pool.mu.Lock()
 	defer pool.mu.Unlock()
 


### PR DESCRIPTION
resolve #168 