### PR TITLE
rename all ethstats to nextats

### DIFF
--- a/cmd/puppeth/module_ethstats.go
+++ b/cmd/puppeth/module_ethstats.go
@@ -37,14 +37,14 @@ RUN echo 'module.exports = {trusted: [{{.Trusted}}], banned: [{{.Banned}}], rese
 `
 
 // ethstatsComposefile is the docker-compose.yml file required to deploy and
-// maintain an ethstats monitoring site.
+// maintain an nextats monitoring site.
 var ethstatsComposefile = `
 version: '2'
 services:
-  ethstats:
+  nextats:
     build: .
     image: {{.Network}}/nextats
-    container_name: {{.Network}}_ethstats_1{{if not .VHost}}
+    container_name: {{.Network}}_nextats_1{{if not .VHost}}
     ports:
       - "{{.Port}}:3000"{{end}}
     environment:
@@ -59,7 +59,7 @@ services:
     restart: always
 `
 
-// deployEthstats deploys a new ethstats container to a remote machine via SSH,
+// deployEthstats deploys a new nextats container to a remote machine via SSH,
 // docker and docker-compose. If an instance with the specified network name
 // already exists there, it will be overwritten!
 func deployEthstats(client *sshClient, network string, port int, secret string, vhost string, trusted []string, banned []string, nocache bool) ([]byte, error) {
@@ -106,7 +106,7 @@ func deployEthstats(client *sshClient, network string, port int, secret string, 
 	return nil, client.Stream(fmt.Sprintf("cd %s && docker-compose -p %s up -d --build --force-recreate --timeout 60", workdir, network))
 }
 
-// ethstatsInfos is returned from an ethstats status check to allow reporting
+// ethstatsInfos is returned from an nextats status check to allow reporting
 // various configuration parameters.
 type ethstatsInfos struct {
 	host   string
@@ -127,11 +127,11 @@ func (info *ethstatsInfos) Report() map[string]string {
 	}
 }
 
-// checkEthstats does a health-check against an ethstats server to verify whether
+// checkEthstats does a health-check against an nextats server to verify whether
 // it's running, and if yes, gathering a collection of useful infos about it.
 func checkEthstats(client *sshClient, network string) (*ethstatsInfos, error) {
-	// Inspect a possible ethstats container on the host
-	infos, err := inspectContainer(client, fmt.Sprintf("%s_ethstats_1", network))
+	// Inspect a possible nextats container on the host
+	infos, err := inspectContainer(client, fmt.Sprintf("%s_nextats_1", network))
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func checkEthstats(client *sshClient, network string) (*ethstatsInfos, error) {
 
 	// Run a sanity check to see if the port is reachable
 	if err = checkPort(host, port); err != nil {
-		log.Warn("Ethstats service seems unreachable", "server", host, "port", port, "err", err)
+		log.Warn("Nexstats service seems unreachable", "server", host, "port", port, "err", err)
 	}
 	// Container available, assemble and return the useful infos
 	return &ethstatsInfos{

--- a/cmd/puppeth/wizard_ethstats.go
+++ b/cmd/puppeth/wizard_ethstats.go
@@ -23,7 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-// deployEthstats queries the user for various input on deploying an ethstats
+// deployEthstats queries the user for various input on deploying an nextats
 // monitoring server, after which it executes it.
 func (w *wizard) deployEthstats() {
 	// Select the server to interact with
@@ -33,7 +33,7 @@ func (w *wizard) deployEthstats() {
 	}
 	client := w.servers[server]
 
-	// Retrieve any active ethstats configurations from the server
+	// Retrieve any active nextats configurations from the server
 	infos, err := checkEthstats(client, w.network)
 	if err != nil {
 		infos = &ethstatsInfos{
@@ -46,15 +46,15 @@ func (w *wizard) deployEthstats() {
 
 	// Figure out which port to listen on
 	fmt.Println()
-	fmt.Printf("Which port should ethstats listen on? (default = %d)\n", infos.port)
+	fmt.Printf("Which port should nextats listen on? (default = %d)\n", infos.port)
 	infos.port = w.readDefaultInt(infos.port)
 
-	// Figure which virtual-host to deploy ethstats on
+	// Figure which virtual-host to deploy nextats on
 	if infos.host, err = w.ensureVirtualHost(client, infos.port, infos.host); err != nil {
-		log.Error("Failed to decide on ethstats host", "err", err)
+		log.Error("Failed to decide on nextats host", "err", err)
 		return
 	}
-	// Port and proxy settings retrieved, figure out the secret and boot ethstats
+	// Port and proxy settings retrieved, figure out the secret and boot nextats
 	fmt.Println()
 	if infos.secret == "" {
 		fmt.Printf("What should be the secret password for the API? (must not be empty)\n")
@@ -101,11 +101,11 @@ func (w *wizard) deployEthstats() {
 			sort.Strings(infos.banned)
 		}
 	}
-	// Try to deploy the ethstats server on the host
+	// Try to deploy the nextats server on the host
 	nocache := false
 	if existed {
 		fmt.Println()
-		fmt.Printf("Should the ethstats be built from scratch (y/n)? (default = no)\n")
+		fmt.Printf("Should the nextats be built from scratch (y/n)? (default = no)\n")
 		nocache = w.readDefaultYesNo(false)
 	}
 	trusted := make([]string, 0, len(w.servers))
@@ -115,7 +115,7 @@ func (w *wizard) deployEthstats() {
 		}
 	}
 	if out, err := deployEthstats(client, w.network, infos.port, infos.secret, infos.host, trusted, infos.banned, nocache); err != nil {
-		log.Error("Failed to deploy ethstats container", "err", err)
+		log.Error("Failed to deploy nextats container", "err", err)
 		if len(out) > 0 {
 			fmt.Printf("%s\n", out)
 		}

--- a/cmd/puppeth/wizard_explorer.go
+++ b/cmd/puppeth/wizard_explorer.go
@@ -49,7 +49,7 @@ func (w *wizard) deployExplorer() {
 	fmt.Printf("Which port should the explorer listen on? (default = %d)\n", infos.webPort)
 	infos.webPort = w.readDefaultInt(infos.webPort)
 
-	// Figure which virtual-host to deploy ethstats on
+	// Figure which virtual-host to deploy nextats on
 	if infos.webHost, err = w.ensureVirtualHost(client, infos.webPort, infos.webHost); err != nil {
 		log.Error("Failed to decide on explorer host", "err", err)
 		return

--- a/cmd/puppeth/wizard_intro.go
+++ b/cmd/puppeth/wizard_intro.go
@@ -49,7 +49,7 @@ func (w *wizard) run() {
 	fmt.Println("| Welcome to puppeth, your Ethereum private network manager |")
 	fmt.Println("|                                                           |")
 	fmt.Println("| This tool lets you create a new Ethereum network down to  |")
-	fmt.Println("| the genesis block, bootnodes, miners and ethstats servers |")
+	fmt.Println("| the genesis block, bootnodes, miners and nextats servers |")
 	fmt.Println("| without the hassle that it would normally entail.         |")
 	fmt.Println("|                                                           |")
 	fmt.Println("| Puppeth uses SSH to dial in to remote servers, and builds |")

--- a/cmd/puppeth/wizard_netstats.go
+++ b/cmd/puppeth/wizard_netstats.go
@@ -104,13 +104,13 @@ func (w *wizard) gatherStats(server string, pubkey []byte, client *sshClient) *s
 	} else {
 		stat.services["nginx"] = infos.Report()
 	}
-	logger.Debug("Checking for ethstats availability")
+	logger.Debug("Checking for nextats availability")
 	if infos, err := checkEthstats(client, w.network); err != nil {
 		if err != ErrServiceUnknown {
-			stat.services["ethstats"] = map[string]string{"offline": err.Error()}
+			stat.services["nextats"] = map[string]string{"offline": err.Error()}
 		}
 	} else {
-		stat.services["ethstats"] = infos.Report()
+		stat.services["nextats"] = infos.Report()
 		ethstats = infos.config
 	}
 	logger.Debug("Checking for bootnode availability")


### PR DESCRIPTION
rename to `nextats` also is necessary to tear down the stats properly on remote server 