### PR TITLE
dccs: use state.IntermediateRoot in between state change

### DIFF
--- a/consensus/dccs/dccs.go
+++ b/consensus/dccs/dccs.go
@@ -1038,7 +1038,7 @@ func (d *Dccs) Initialize(chain consensus.ChainReader, header *types.Header, sta
 			log.Error("Failed to deploy Endurio stablecoin contracts", "err", err)
 			return nil, nil, err
 		}
-		state.Commit(false)
+		header.Root = state.IntermediateRoot(false)
 		log.Info("⚙ Successfully deploy Endurio stablecoin contracts")
 		return nil, nil, nil
 	}
@@ -1049,6 +1049,7 @@ func (d *Dccs) Initialize(chain consensus.ChainReader, header *types.Header, sta
 		}
 		if rate != nil {
 			d.PriceEngine().RecordNewAbsorptionRate(state, rate, chain)
+			header.Root = state.IntermediateRoot(false)
 		}
 	}
 	absorption, err := d.PriceEngine().CalcNextAbsorption(chain, header)
@@ -1060,6 +1061,7 @@ func (d *Dccs) Initialize(chain consensus.ChainReader, header *types.Header, sta
 		if err != nil {
 			return nil, nil, err
 		}
+		header.Root = state.IntermediateRoot(false)
 	}
 
 	return nil, nil, nil
@@ -1111,9 +1113,7 @@ func absorb(state *state.StateDB, absorption *big.Int, chain consensus.ChainRead
 	}
 	// update the new balance after absorption
 	state.SetBalance(params.VolatileTokenAddress, supply)
-
-	_, err = state.Commit(false)
-	return err
+	return nil
 }
 
 // Finalize implements consensus.Engine, ensuring no uncles are set, nor block

--- a/consensus/dccs/price_engine.go
+++ b/consensus/dccs/price_engine.go
@@ -174,7 +174,6 @@ func (e *PriceEngine) RecordNewAbsorptionRate(state *state.StateDB, rate *Price,
 	}
 	number := chain.CurrentHeader().Number
 	e.setNewAbsorption(state, number, supply, targetSupply)
-	state.Commit(false)
 	return nil
 }
 


### PR DESCRIPTION
.. and update the Header.Root to fix the race condition in case txpool.reset and worker.commitNewWork is called.

To solve #232