### PR TITLE
dccs: return error when data/state is missing

### DIFF
--- a/consensus/dccs/dccs.go
+++ b/consensus/dccs/dccs.go
@@ -630,6 +630,9 @@ func (d *Dccs) snapshot2(chain consensus.ChainReader, number uint64, hash common
 			} else {
 				return nil, fmt.Errorf("Epoch checkpoint data is not available")
 			}
+		} else {
+			// cannot get data from db in the --fast sync mode
+			return nil, fmt.Errorf("checkpoint header is not available")
 		}
 	}
 


### PR DESCRIPTION
in the `--fast` sync mode, the chain data/state are not available then cannot run `--fast` sync mode in the current nexty mainnet. The bug was report in #214 

This PR is only to output the error log obviously when the data/state is missing on the chain/db to avoid infinite loop. To support `--fast` sync mode, we need do in other task/issue. 