### PR TITLE
fast-sync

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1614,7 +1614,8 @@ Error: %v
 // because nonces can be verified sparsely, not needing to check each.
 func (bc *BlockChain) InsertHeaderChain(chain []*types.Header, checkFreq int) (int, error) {
 	start := time.Now()
-	if i, err := bc.hc.ValidateHeaderChain(chain, checkFreq); err != nil {
+	fastSyncing := bc.CurrentBlock().Number().Cmp(bc.CurrentFastBlock().Number()) < 0
+	if i, err := bc.hc.ValidateHeaderChain(chain, checkFreq, fastSyncing); err != nil {
 		return i, err
 	}
 

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -35,7 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru"
 )
 
 var (
@@ -356,7 +356,7 @@ func (self *LightChain) postChainEvents(events []interface{}) {
 // chain events when necessary.
 func (self *LightChain) InsertHeaderChain(chain []*types.Header, checkFreq int) (int, error) {
 	start := time.Now()
-	if i, err := self.hc.ValidateHeaderChain(chain, checkFreq); err != nil {
+	if i, err := self.hc.ValidateHeaderChain(chain, checkFreq, true); err != nil {
 		return i, err
 	}
 


### PR DESCRIPTION
Lower chain security for fast-sync support. Only use fast-sync when connected to trusted nodes.

To solve #214 