### PR TITLE
dccs: looping until data/state are available on local

### DIFF
--- a/consensus/dccs/dccs.go
+++ b/consensus/dccs/dccs.go
@@ -589,8 +589,7 @@ func (d *Dccs) snapshot2(chain consensus.ChainReader, number uint64, hash common
 	for snap == nil {
 		// Get signers from Nexty staking smart contract at the latest epoch checkpoint from block number
 		cp := d.config.Snapshot(number + 1)
-		checkpoint := chain.GetHeaderByNumber(cp)
-		if checkpoint != nil {
+		if checkpoint := chain.GetHeaderByNumber(cp); checkpoint != nil {
 			hash := checkpoint.Hash()
 			log.Trace("Reading signers from epoch checkpoint", "number", cp, "hash", hash)
 			// If an in-memory snapshot was found, use that
@@ -623,8 +622,11 @@ func (d *Dccs) snapshot2(chain consensus.ChainReader, number uint64, hash common
 					d.recents.Add(snap.Hash, snap)
 					break
 				}
+				log.Error("state is not available", "number", cp, "hash", hash)
 			}
+			log.Error("state is not available", "number", cp, "hash", hash)
 		}
+		log.Warn("Need to wait for applying pending txs to build data/state available")
 	}
 
 	// Set current block number for snapshot to calculate the inturn & difficulty

--- a/consensus/dccs/dccs.go
+++ b/consensus/dccs/dccs.go
@@ -20,7 +20,6 @@ package dccs
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
 	"math"
 	"math/big"
@@ -600,34 +599,30 @@ func (d *Dccs) snapshot2(chain consensus.ChainReader, number uint64, hash common
 				log.Trace("Loading snapshot from mem-cache", "hash", snap.Hash, "length", len(snap.signers()))
 				break
 			}
-			state, err := chain.StateAt(checkpoint.Root)
-			if state == nil || err != nil {
-				log.Error("Cannot read state of the checkpoint header", "err", err, "number", cp, "hash", hash, "root", checkpoint.Root)
-				return nil, fmt.Errorf("cannot read state of checkpoint header: %v", err)
-			}
-			size := state.GetCodeSize(chain.Config().Dccs.Contract)
-			if size > 0 && state.Error() == nil {
-				index := common.BigToHash(common.Big0)
-				result := state.GetState(chain.Config().Dccs.Contract, index)
-				var length int64
-				if (result == common.Hash{}) {
-					length = 0
-				} else {
-					length = result.Big().Int64()
+			if state, err := chain.StateAt(checkpoint.Root); state != nil && err == nil {
+				if size := state.GetCodeSize(chain.Config().Dccs.Contract); size > 0 && state.Error() == nil {
+					index := common.BigToHash(common.Big0)
+					result := state.GetState(chain.Config().Dccs.Contract, index)
+					var length int64
+					if (result == common.Hash{}) {
+						length = 0
+					} else {
+						length = result.Big().Int64()
+					}
+					log.Trace("Total number of signer from staking smart contract", "length", length)
+					signers := make([]common.Address, length)
+					key := crypto.Keccak256Hash(hexutil.MustDecode(index.String()))
+					for i := 0; i < len(signers); i++ {
+						log.Trace("key hash", "key", key)
+						singer := state.GetState(chain.Config().Dccs.Contract, key)
+						signers[i] = common.HexToAddress(singer.Hex())
+						key = key.Plus()
+					}
+					snap = newSnapshot(d.config, d.signatures, number, hash, signers)
+					// Store found snapshot into mem-cache
+					d.recents.Add(snap.Hash, snap)
+					break
 				}
-				log.Trace("Total number of signer from staking smart contract", "length", length)
-				signers := make([]common.Address, length)
-				key := crypto.Keccak256Hash(hexutil.MustDecode(index.String()))
-				for i := 0; i < len(signers); i++ {
-					log.Trace("key hash", "key", key)
-					singer := state.GetState(chain.Config().Dccs.Contract, key)
-					signers[i] = common.HexToAddress(singer.Hex())
-					key = key.Plus()
-				}
-				snap = newSnapshot(d.config, d.signatures, number, hash, signers)
-				// Store found snapshot into mem-cache
-				d.recents.Add(snap.Hash, snap)
-				break
 			}
 		}
 	}

--- a/consensus/dccs/dccs.go
+++ b/consensus/dccs/dccs.go
@@ -586,6 +586,7 @@ func (d *Dccs) snapshot2(chain consensus.ChainReader, number uint64, hash common
 	var (
 		snap *Snapshot
 	)
+	// looping until data/state are available on local
 	for snap == nil {
 		// Get signers from Nexty staking smart contract at the latest epoch checkpoint from block number
 		cp := d.config.Snapshot(number + 1)
@@ -627,12 +628,7 @@ func (d *Dccs) snapshot2(chain consensus.ChainReader, number uint64, hash common
 				// Store found snapshot into mem-cache
 				d.recents.Add(snap.Hash, snap)
 				break
-			} else {
-				return nil, fmt.Errorf("Epoch checkpoint data is not available")
 			}
-		} else {
-			// cannot get data from db in the --fast sync mode
-			return nil, fmt.Errorf("checkpoint header is not available")
 		}
 	}
 

--- a/consensus/dccs/snapshot.go
+++ b/consensus/dccs/snapshot.go
@@ -376,7 +376,7 @@ func (s *Snapshot) offset(signer common.Address, parent *types.Header) (int, err
 
 	if parent == nil || s.config.IsCheckpoint(parent.Number.Uint64()+1) {
 		// first block of an epoch, just return the rightful order
-		log.Info("the first block of an epoch")
+		log.Debug("the first block of an epoch")
 		return pos, nil
 	}
 
@@ -396,7 +396,7 @@ func (s *Snapshot) offset(signer common.Address, parent *types.Header) (int, err
 		offset += n
 	}
 
-	log.Info("offset", "signer position", pos, "previous signer position", prevPos, "len(signers)", n, "offset", offset)
+	log.Debug("offset", "signer position", pos, "previous signer position", prevPos, "len(signers)", n, "offset", offset)
 
 	return offset, nil
 }


### PR DESCRIPTION
if return error when missing state as in #236 then peers will be dropped then node need to wait until data/state are available on local db to proceed syncing

=== Edit by @Zergity ===
While full-syncing, header verifcation happens before state change is applied. So in case the header verification of block N, the snapshot state of N in block epoch(N)-7 is not available yet, making the verification process failed.